### PR TITLE
chore(deps): pin lombok to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<version>1.18.30</version>
 			<scope>provided</scope>
 		</dependency>
 


### PR DESCRIPTION
fails to build on macos arm64 with openjdk@11 (brew)